### PR TITLE
Add support for dynamic headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,30 @@ client.request(query, variables).then(data => console.log(data))
 
 ## Examples
 
+### Dynamic headers
+
+```js
+import { GraphQLClient } from 'graphql-request'
+import store from './store'
+
+const client = new GraphQLClient('my-endpoint', {
+  headers: {
+    Authorization: () => store.getIdentity().getToken(),
+  },
+})
+
+const query = `{
+  Movie(title: "Inception") {
+    releaseDate
+    actors {
+      name
+    }
+  }
+}`
+
+client.request(query).then(data => console.log(data))
+```
+
 ### Authentication via HTTP header
 
 ```js

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { ClientError, GraphQLError, Headers as HttpHeaders, Options, Variables } from './types'
+import { ClientError, DynamicHeaders, DynamicHeaderValue, GraphQLError, Headers as HttpHeaders, Options, Variables } from './types'
 export { ClientError } from './types'
 import 'cross-fetch/polyfill'
 
@@ -24,7 +24,7 @@ export class GraphQLClient {
 
     const response = await fetch(this.url, {
       method: 'POST',
-      headers: Object.assign({ 'Content-Type': 'application/json' }, headers),
+      headers: this.processHeaders(Object.assign({ 'Content-Type': 'application/json' }, headers)),
       body,
       ...others,
     })
@@ -57,7 +57,7 @@ export class GraphQLClient {
 
     const response = await fetch(this.url, {
       method: 'POST',
-      headers: Object.assign({ 'Content-Type': 'application/json' }, headers),
+      headers: this.processHeaders(Object.assign({ 'Content-Type': 'application/json' }, headers)),
       body,
       ...others,
     })
@@ -91,6 +91,15 @@ export class GraphQLClient {
       this.options.headers = { [key]: value }
     }
     return this
+  }
+
+  processHeaders(headers: DynamicHeaders): HttpHeaders {
+    for (let name in headers) {
+      if (typeof headers[name] === 'function') {
+        headers[name] = (headers[name] as DynamicHeaderValue)()
+      }
+    }
+    return headers as HttpHeaders
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,18 @@
 export type Variables = { [key: string]: any }
 
+export interface DynamicHeaderValue {
+  (): string
+}
+export interface DynamicHeaders {
+  [key: string]: string | DynamicHeaderValue
+}
 export interface Headers {
   [key: string]: string
 }
 
 export interface Options {
   method?: RequestInit['method']
-  headers?: Headers
+  headers?: DynamicHeaders
   mode?: RequestInit['mode']
   credentials?: RequestInit['credentials']
   cache?: RequestInit['cache']

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -124,6 +124,21 @@ test('extra fetch options', async (t) => {
   })
 })
 
+test('dynamic header', async (t) => {
+  const HEADER_VALUE = 'dynmic header value'
+  const client = new GraphQLClient('https://mock-api.com/graphql', {
+    headers: {
+      'Authorization': () => {return HEADER_VALUE}
+    }
+  })
+  await mock({
+    body: { data: {test: 'test'} }
+  }, async () => {
+    await client.request('query { test }')
+    t.deepEqual(fetchMock.lastCall()[1].headers!['Authorization'], HEADER_VALUE)
+  })
+})
+
 async function mock(response: any, testFn: () => Promise<void>) {
   fetchMock.mock({
     matcher: '*',


### PR DESCRIPTION
Motivation (for example):
We want get actual user authorization token from store for each request. Now we must create a new client for each request and is not optimal.
Can be used for others dynamic values which can be modified

```js
import { GraphQLClient } from 'graphql-request'
import store from './store'

const client = new GraphQLClient('my-endpoint', {
  headers: {
    // Now we can get actual token from store for each request
    Authorization: () => store.getIdentity().getToken(),
  },
})

const query = `{
  Movie(title: "Inception") {
    releaseDate
    actors {
      name
    }
  }
}`

client.request(query).then(data => console.log(data))
```