### PR TITLE
feat: drop cross-fetch polyfill dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,7 @@
     "test": "npm run lint && npm run build && ava --serial && npm run size",
     "size": "bundlesize"
   },
-  "dependencies": {
-    "cross-fetch": "2.2.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/fetch-mock": "5.12.2",
     "@types/node": "8.5.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { ClientError, GraphQLError, Headers as HttpHeaders, Options, Variables } from './types'
 export { ClientError } from './types'
-import 'cross-fetch/polyfill'
 
 export class GraphQLClient {
   private url: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,13 +1013,6 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
-cross-fetch@2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
-  dependencies:
-    node-fetch "2.1.2"
-    whatwg-fetch "2.0.4"
-
 cross-spawn@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -2192,10 +2185,6 @@ node-abi@^2.2.0:
   dependencies:
     semver "^5.4.1"
 
-node-fetch@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
-
 node-fetch@^1.3.3:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.0.tgz#3ff6c56544f9b7fb00682338bb55ee6f54a8a0ef"
@@ -3355,10 +3344,6 @@ verror@1.3.6:
 well-known-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/well-known-symbols/-/well-known-symbols-1.0.0.tgz#73c78ae81a7726a8fa598e2880801c8b16225518"
-
-whatwg-fetch@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 
 which-pm-runs@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
It's better if polyfill will be included on the application level rather than having it included by each similar to this vendor package (each may include different polyfill, which turns into bloated app). In my case "cross-fetch" doesn't make sense because I use `@babel/polyfill`