### PR TITLE
feat: export `Options` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { ClientError, GraphQLError, Headers as HttpHeaders, Options, Variables } from './types'
-export { ClientError } from './types'
+export { ClientError, Options } from './types'
 import 'cross-fetch/polyfill'
 
 export class GraphQLClient {


### PR DESCRIPTION
Useful to use the `Options`-object. Easier to import from the base file than doing `import { Options as GraphQLClientOptions } from 'graphql-request/dist/src/types'`