### PR TITLE
refactor: remove unused `async` keywords

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,7 @@ export async function request<T extends any>(
 
 export default request
 
-async function getResult(response: Response): Promise<any> {
+function getResult(response: Response): Promise<any> {
   const contentType = response.headers.get('Content-Type')
   if (contentType && contentType.startsWith('application/json')) {
     return response.json()

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ export class GraphQLClient {
   }
 }
 
-export async function rawRequest<T extends any>(
+export function rawRequest<T extends any>(
   url: string,
   query: string,
   variables?: Variables,
@@ -104,7 +104,7 @@ export async function rawRequest<T extends any>(
   return client.rawRequest<T>(query, variables)
 }
 
-export async function request<T extends any>(
+export function request<T extends any>(
   url: string,
   query: string,
   variables?: Variables,


### PR DESCRIPTION
When func. was refactored last time it returned resolved promise, now it returns
Promise, hense async not needed since no await is used anywhere inside
the body.

Here is reference to when async was needed
https://github.com/prisma-labs/graphql-request/blame/fcb46735ff6f825090d9327bc9e2e69e12abaf79/src/index.ts#L49