### PR TITLE
feat: support passing custom fetch into GraphQLClient constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import { request, GraphQLClient } from 'graphql-request'
 request(endpoint, query, variables).then((data) => console.log(data))
 
 // ... or create a GraphQL client instance to send requests
-const client = new GraphQLClient(endpoint, { headers: {} })
+const client = new GraphQLClient(endpoint, { headers: {}, fetch: customFetch })
 client.request(query, variables).then((data) => console.log(data))
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import fetch from 'cross-fetch'
+import crossFetch from 'cross-fetch'
 import { ClientError, GraphQLError, Variables } from './types'
 import { Request, RequestInit, Response } from './types.dom'
 
@@ -23,14 +23,14 @@ export class GraphQLClient {
     status: number
     errors?: GraphQLError[]
   }> {
-    const { headers, ...others } = this.options
+    const { headers, fetch: localFetch = crossFetch, ...others } = this.options
 
     const body = JSON.stringify({
       query,
       variables: variables ? variables : undefined,
     })
 
-    const response = await fetch(this.url, {
+    const response = await localFetch(this.url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...headers },
       body,
@@ -52,14 +52,14 @@ export class GraphQLClient {
   }
 
   async request<T = any>(query: string, variables?: Variables): Promise<T> {
-    const { headers, ...others } = this.options
+    const { headers, fetch: localFetch = crossFetch, ...others } = this.options
 
     const body = JSON.stringify({
       query,
       variables: variables ? variables : undefined,
     })
 
-    const response = await fetch(this.url, {
+    const response = await localFetch(this.url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...headers },
       body,

--- a/src/types.dom.ts
+++ b/src/types.dom.ts
@@ -293,6 +293,7 @@ export interface RequestInit {
   referrerPolicy?: ReferrerPolicy
   signal?: AbortSignal | null
   window?: any
+  fetch?: any
 }
 
 interface Body {


### PR DESCRIPTION
Addresses #40, needs documentation and tests.

Use like so:
```js
import { GraphQLClient } from 'graphql-request'

const client = new GraphQLClient(endpoint, { fetch: myCustomFetch })
```
