### PR TITLE
feat!: accept DocumentNode input

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Minimal GraphQL client supporting Node and browsers for scripts or simple apps
 ## Install
 
 ```sh
-npm add graphql-request
+npm add graphql-request graphql
 ```
 
 ## Quickstart
@@ -22,16 +22,18 @@ npm add graphql-request
 Send a GraphQL query with a single line of code. ▶️ [Try it out](https://runkit.com/593130bdfad7120012472003/593130bdfad7120012472004).
 
 ```js
-import { request } from 'graphql-request'
+import { request, gql } from 'graphql-request'
 
-const query = `{
-  Movie(title: "Inception") {
-    releaseDate
-    actors {
-      name
+const query = gql`
+  {
+    Movie(title: "Inception") {
+      releaseDate
+      actors {
+        name
+      }
     }
   }
-}`
+`
 
 request('https://api.graph.cool/simple/v1/movies', query).then((data) => console.log(data))
 ```
@@ -54,7 +56,7 @@ client.request(query, variables).then((data) => console.log(data))
 ### Authentication via HTTP header
 
 ```js
-import { GraphQLClient } from 'graphql-request'
+import { GraphQLClient, gql } from 'graphql-request'
 
 async function main() {
   const endpoint = 'https://api.graph.cool/simple/v1/cixos23120m0n0173veiiwrjr'
@@ -65,7 +67,7 @@ async function main() {
     },
   })
 
-  const query = /* GraphQL */ `
+  const query = gql`
     {
       Movie(title: "Inception") {
         releaseDate
@@ -86,6 +88,7 @@ main().catch((error) => console.error(error))
 [TypeScript Source](examples/authentication-via-http-header.ts)
 
 #### Dynamically setting headers
+
 If you want to set headers after the GraphQLClient has been initialised, you can use the `setHeader()` or `setHeaders()` functions.
 
 ```js
@@ -106,7 +109,7 @@ client.setHeaders({
 ### Passing more options to fetch
 
 ```js
-import { GraphQLClient } from 'graphql-request'
+import { GraphQLClient, gql } from 'graphql-request'
 
 async function main() {
   const endpoint = 'https://api.graph.cool/simple/v1/cixos23120m0n0173veiiwrjr'
@@ -116,7 +119,7 @@ async function main() {
     mode: 'cors',
   })
 
-  const query = /* GraphQL */ `
+  const query = gql`
     {
       Movie(title: "Inception") {
         releaseDate
@@ -139,12 +142,12 @@ main().catch((error) => console.error(error))
 ### Using variables
 
 ```js
-import { request } from 'graphql-request'
+import { request, gql } from 'graphql-request'
 
 async function main() {
   const endpoint = 'https://api.graph.cool/simple/v1/cixos23120m0n0173veiiwrjr'
 
-  const query = /* GraphQL */ `
+  const query = gql`
     query getMovie($title: String!) {
       Movie(title: $title) {
         releaseDate
@@ -171,12 +174,12 @@ main().catch((error) => console.error(error))
 ### Error handling
 
 ```js
-import { request } from 'graphql-request'
+import { request, gql } from 'graphql-request'
 
 async function main() {
   const endpoint = 'https://api.graph.cool/simple/v1/cixos23120m0n0173veiiwrjr'
 
-  const query = /* GraphQL */ `
+  const query = gql`
     {
       Movie(title: "Inception") {
         releaseDate
@@ -204,12 +207,12 @@ main().catch((error) => console.error(error))
 ### Using `require` instead of `import`
 
 ```js
-const { request } = require('graphql-request')
+const { request, gql } = require('graphql-request')
 
 async function main() {
   const endpoint = 'https://api.graph.cool/simple/v1/cixos23120m0n0173veiiwrjr'
 
-  const query = /* GraphQL */ `
+  const query = gql`
     {
       Movie(title: "Inception") {
         releaseDate
@@ -236,7 +239,7 @@ npm install fetch-cookie
 ```js
 require('fetch-cookie/node-fetch')(require('node-fetch'))
 
-import { GraphQLClient } from 'graphql-request'
+import { GraphQLClient, gql } from 'graphql-request'
 
 async function main() {
   const endpoint = 'https://api.graph.cool/simple/v1/cixos23120m0n0173veiiwrjr'
@@ -247,7 +250,7 @@ async function main() {
     },
   })
 
-  const query = /* GraphQL */ `
+  const query = gql`
     {
       Movie(title: "Inception") {
         releaseDate
@@ -273,12 +276,12 @@ The `request` method will return the `data` or `errors` key from the response.
 If you need to access the `extensions` key you can use the `rawRequest` method:
 
 ```js
-import { rawRequest } from 'graphql-request'
+import { rawRequest, gql } from 'graphql-request'
 
 async function main() {
   const endpoint = 'https://api.graph.cool/simple/v1/cixos23120m0n0173veiiwrjr'
 
-  const query = /* GraphQL */ `
+  const query = gql`
     {
       Movie(title: "Inception") {
         releaseDate

--- a/README.md
+++ b/README.md
@@ -308,7 +308,15 @@ main().catch((error) => console.error(error))
 
 ## FAQ
 
-### What's the difference between `graphql-request`, Apollo and Relay?
+#### Why do I have to install `graphql`?
+
+`graphql-request` uses a TypeScript type from the `graphql` package such that if you are using TypeScript to build your project and you are using `graphql-request` but don't have `graphql` installed TypeScript build will fail. Details [here](https://github.com/prisma-labs/graphql-request/pull/183#discussion_r464453076). If you are a JS user then you do not technically need to install `graphql`. However if you use an IDE that picks up TS types even for JS (like VSCode) then its still in your interest to install `graphql` so that you can benefit from enhanced type safety during development.
+
+#### Do I need to wrap my GraphQL documents inside the `gql` template exported by `graphql-request`?
+
+No. It is there for convenience so that you can get the tooling support like prettier formatting and IDE syntax highlighting. You can use `gql` from `graphql-tag` if you need it for some reason too.
+
+#### What's the difference between `graphql-request`, Apollo and Relay?
 
 `graphql-request` is the most minimal and simplest to use GraphQL client. It's perfect for small scripts or simple apps.
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
   "dependencies": {
     "cross-fetch": "^3.0.4"
   },
+  "peerDependencies": {
+    "graphql": "14.x || 15.x"
+  },
   "devDependencies": {
     "@prisma-labs/prettier-config": "^0.1.0",
     "@types/body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "dripip": "^0.9.0",
     "express": "^4.17.1",
     "fetch-cookie": "0.7.2",
+    "graphql": "^15.3.0",
+    "graphql-tag": "^2.11.0",
     "jest": "^26.0.1",
     "prettier": "^2.0.5",
     "ts-jest": "^26.0.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { DocumentNode } from 'graphql/language/ast'
+import type { DocumentNode } from 'graphql/language/ast'
 
 export type Variables = { [key: string]: any }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { DocumentNode } from 'graphql/language/ast'
+
 export type Variables = { [key: string]: any }
 
 export interface GraphQLError {
@@ -50,3 +52,5 @@ export class ClientError extends Error {
     }
   }
 }
+
+export type RequestDocument = string | DocumentNode

--- a/yarn.lock
+++ b/yarn.lock
@@ -2344,6 +2344,16 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
+graphql-tag@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.11.0.tgz#1deb53a01c46a7eb401d6cb59dec86fa1cccbffd"
+  integrity sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==
+
+graphql@^15.3.0:
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
+  integrity sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"


### PR DESCRIPTION
closes #176

Example:

```ts
import gql from 'graphql-tag'

await request('https://foo.bar/graphql', gql`...`)
```

If you don't actually care about using DocumentNode but just
want the tooling support for gql template tag like IDE syntax
coloring and prettier autoformat then note you can use the
passthrough gql tag shipped with graphql-request to save a bit
of performance and not have to install another dep into your project.

```ts
import { gql } from 'graphql-request'

await request('https://foo.bar/graphql', gql`...`)
```

BREAKING CHANGE:

`graphql-request` now requires `graphql` version 14.x or 15.x as a peer dependency.

`graphql-request` uses a TypeScript type from the `graphql` package such that if you are using TypeScript to build your project and you are using `graphql-request` but don't have `graphql` installed TypeScript build will fail. Details [here](https://github.com/prisma-labs/graphql-request/pull/183#discussion_r464453076). If you are a JS user then you do not technically need to install `graphql`. However if you use an IDE that picks up TS types even for JS (like VSCode) then its still in your interest to install `graphql` so that you can benefit from enhanced type safety during development.