### PR TITLE
chore: add node engine dep option for node@v15.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/prisma/graphql-request/issues"
   },
   "engines": {
-    "node": "10.x || 12.x || 14.x"
+    "node": "10.x || 12.x || 14.x || 15.x"
   },
   "homepage": "https://github.com/prisma/graphql-request",
   "scripts": {


### PR DESCRIPTION
Seeing this error in some projects:
![image](https://user-images.githubusercontent.com/643503/96926688-bde62e80-146a-11eb-84af-05d8ce18ef0c.png)

Adds 15.x as OR option, tests run clean.

![image](https://user-images.githubusercontent.com/643503/96926786-e3733800-146a-11eb-856f-5a76083219e9.png)

