### PR TITLE
fix: include headers in ClientError response (#245)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,10 @@ export class GraphQLClient {
       return result.data
     } else {
       const errorResult = typeof result === 'string' ? { error: result } : result
-      throw new ClientError({ ...errorResult, status: response.status }, { query: resolvedDoc, variables })
+      throw new ClientError(
+        { ...errorResult, status: response.status, headers: response.headers },
+        { query: resolvedDoc, variables }
+      )
     }
   }
 

--- a/tests/general.test.ts
+++ b/tests/general.test.ts
@@ -93,7 +93,7 @@ test('basic error', async () => {
   const res = await request(ctx.url, `x`).catch((x) => x)
 
   expect(res).toMatchInlineSnapshot(
-    `[Error: GraphQL Error (Code: 200): {"response":{"errors":{"message":"Syntax Error GraphQL request (1:1) Unexpected Name \\"x\\"\\n\\n1: x\\n   ^\\n","locations":[{"line":1,"column":1}]},"status":200},"request":{"query":"x"}}]`
+    `[Error: GraphQL Error (Code: 200): {"response":{"errors":{"message":"Syntax Error GraphQL request (1:1) Unexpected Name \\"x\\"\\n\\n1: x\\n   ^\\n","locations":[{"line":1,"column":1}]},"status":200,"headers":{}},"request":{"query":"x"}}]`
   )
 })
 


### PR DESCRIPTION
Fixes #245 

This adds `headers` to `ClientError` in `request` the same way that it is done for `rawRequest`:

https://github.com/prisma-labs/graphql-request/blob/5b233c5658e65ed0d98cf8bff50beec413f399b9/src/index.ts#L71-L73