### PR TITLE
feat: passthrough headers on exported request function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -180,10 +180,11 @@ export async function rawRequest<T = any, V = Variables>(
 export async function request<T = any, V = Variables>(
   url: string,
   document: RequestDocument,
-  variables?: V
+  variables?: V,
+  requestHeaders?: Dom.RequestInit['headers']
 ): Promise<T> {
   const client = new GraphQLClient(url)
-  return client.request<T, V>(document, variables)
+  return client.request<T, V>(document, variables, requestHeaders)
 }
 
 export default request

--- a/tests/headers.test.ts
+++ b/tests/headers.test.ts
@@ -1,6 +1,6 @@
 import * as CrossFetch from 'cross-fetch'
 import * as Dom from '../src/types.dom'
-import { GraphQLClient } from '../src'
+import { GraphQLClient, request } from '../src'
 import { setupTestServer } from './__helpers'
 
 const ctx = setupTestServer()
@@ -92,5 +92,20 @@ describe('using class', () => {
       });
 
     })
+  })
+})
+
+describe('using request function', () => {
+  describe.each([
+    [new H({ 'x-request-foo': 'request-bar' })],
+    [{ 'x-request-foo': 'request-bar' }],
+    [[['x-request-foo', 'request-bar']]]
+  ])('request unique header with request', (headerCase: Dom.RequestInit['headers']) => {
+    test('sets header', async () => {
+      const mock = ctx.res()
+      await request(ctx.url, `{ me { id } }`, {}, headerCase)
+
+      expect(mock.requests[0].headers['x-request-foo']).toEqual('request-bar')
+    });
   })
 })


### PR DESCRIPTION
This will allow headers to be set on the exported request function.