### PR TITLE
chore(ci): refresh node version matrix

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10.x, 12.x, 14.x, 15.x]
+        node: [12, 14, 16]
         environment: [dom, node]
     name: Node ${{ matrix.node }} @env ${{matrix.environment}}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
       - name: Get yarn cache directory path

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10.x, 12.x, 14.x, 15.x]
+        node: [12, 14, 16]
         environment: [dom, node]
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
       - name: Get yarn cache directory path


### PR DESCRIPTION
1. node v10 and v15 are deprecated. node v16 is released. 

2. Upgrade `actions/setup-node` from `v1` to `v2`.