### PR TITLE
fix: types on GraphQLError

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,8 +4,8 @@ export type Variables = { [key: string]: any }
 
 export interface GraphQLError {
   message: string
-  locations: { line: number; column: number }[]
-  path: string[]
+  locations?: { line: number; column: number }[]
+  path?: string[]
   extensions?: any
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface GraphQLError {
   message: string
   locations: { line: number; column: number }[]
   path: string[]
+  extensions?: any
 }
 
 export interface GraphQLResponse<T = any> {


### PR DESCRIPTION
The type signature of `GraphQLError` is not 100% correct, as far as I see:

1. It is common to have `extensions` on each error, which is currently not allowed
2. `locations` and `path` are currently required, but should probably be optional, as you _can_ have errors without them
