### PR TITLE
feat: add operationName to payload if defined in gql

### DIFF
--- a/src/createRequestBody.ts
+++ b/src/createRequestBody.ts
@@ -16,8 +16,8 @@ const isExtractableFileEnhanced = (value: any): value is ExtractableFile | { pip
  * (https://github.com/jaydenseric/graphql-multipart-request-spec)
  * Otherwise returns JSON
  */
-export default function createRequestBody(query: string, variables?: Variables): string | FormData {
-  const { clone, files } = extractFiles({ query, variables }, '', isExtractableFileEnhanced)
+export default function createRequestBody(query: string, variables?: Variables, operationName?: string): string | FormData {
+  const { clone, files } = extractFiles({ query, variables, operationName }, '', isExtractableFileEnhanced)
 
   if (files.size === 0) {
     return JSON.stringify(clone)

--- a/tests/__snapshots__/gql.test.ts.snap
+++ b/tests/__snapshots__/gql.test.ts.snap
@@ -5,10 +5,9 @@ Object {
   "requests": Array [
     Object {
       "body": Object {
-        "query": "{
-  query {
-    users
-  }
+        "operationName": "allUsers",
+        "query": "query allUsers {
+  users
 }
 ",
       },
@@ -16,7 +15,7 @@ Object {
         "accept": "*/*",
         "accept-encoding": "gzip,deflate",
         "connection": "close",
-        "content-length": "45",
+        "content-length": "69",
         "content-type": "application/json",
         "host": "DYNAMIC",
         "user-agent": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",

--- a/tests/gql.test.ts
+++ b/tests/gql.test.ts
@@ -9,13 +9,10 @@ describe('gql', () => {
     const mock = ctx.res({ body: { data: { foo: 1 } } })
     await request(
       ctx.url,
-      gql`
-        {
-          query {
-            users
-          }
-        }
-      `
+      gql`query allUsers {
+  users
+}
+`
     )
     expect(mock).toMatchSnapshot()
   })


### PR DESCRIPTION
We use the operation name for tracking purposes on our API. However, as already discussed here: https://github.com/prisma-labs/graphql-request/issues/64, the operationName is currently not send.

In contrast to issue https://github.com/prisma-labs/graphql-request/issues/64, which is about allowing to define an operationName when sending multiple queries at once, this is about sending the `operationName` field in the payload sent to the API for "regular" queries/mutations like this:

```gql
query allUsers {
  users
}
```

Where I want the server to use `allUsers` for tracking purposes. When we send the `operationName` field in our payload, like e.g. Apollo or some other GraphQL clients do, it can easily be used by GraphQL server implementations. This should be a completely backwards compatible change.

I tried to build this in a completely backwards-compatible way by extracting the actual fetch call from `rawRequest` into a private `makeRequest` function, which is called by both `rawRequest` and `request`. This way, we can pass in the (optional) `operationName` extracted from the `query`, if possible, and use that, without changing the signature of any public method. 
This will basically only do anything if sending a single operation with an operation name present. Otherwise, nothing will change. If not passing a DocumentNode as `query`, but just a string, it will also do nothing.

I also moved the header-normalization out from the post/get methods to the request methods, to keep the get/post methods as minimal as possible.