### PR TITLE
feat: add GraphQLResponseWithErrors type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -17,16 +17,20 @@ export interface GraphQLResponse<T = any> {
   [key: string]: any
 }
 
+export interface GraphQLResponseWithErrors<T = any> extends GraphQLResponse<T> {
+  errors: GraphQLError[]
+}
+
 export interface GraphQLRequestContext<V = Variables> {
   query: string
   variables?: V
 }
 
 export class ClientError extends Error {
-  response: GraphQLResponse
+  response: GraphQLResponseWithErrors
   request: GraphQLRequestContext
 
-  constructor(response: GraphQLResponse, request: GraphQLRequestContext) {
+  constructor(response: GraphQLResponseWithErrors, request: GraphQLRequestContext) {
     const message = `${ClientError.extractMessage(response)}: ${JSON.stringify({
       response,
       request,
@@ -45,9 +49,9 @@ export class ClientError extends Error {
     }
   }
 
-  private static extractMessage(response: GraphQLResponse): string {
+  private static extractMessage(response: GraphQLResponseWithErrors): string {
     try {
-      return response.errors![0].message
+      return response.errors[0].message
     } catch (e) {
       return `GraphQL Error (Code: ${response.status})`
     }


### PR DESCRIPTION
I am using the types in my error handling, and I noticed that the `ClientError`'s `response.errors` field was possibly `undefined` according to the types. 

Though, according to the [spec](https://github.com/graphql/graphql-spec/blob/main/spec/Section%207%20--%20Response.md#errors), it must be present, and [the code is making that assumption](https://github.com/prisma-labs/graphql-request/blob/master/src/types.ts#L50) as well.

So I added a `GraphQLResponseWithErrors` to reflect the presence of the `errors` array.