### PR TITLE
chore(docs): fix TypeScript spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Minimal GraphQL client supporting Node and browsers for scripts or simple apps
 
 - Most **simple & lightweight** GraphQL client
 - Promise-based API (works with `async` / `await`)
-- Typescript support
+- TypeScript support
 - Isomorphic (works with Node / browsers)
 
 ## Install


### PR DESCRIPTION
Just a minor typo fix: `Typescript` -> `TypeScript`.