### PR TITLE
Support set endpoint after the GraphQLClient has been initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ client.setHeaders({
 })
 ```
 
+#### Set endpoint
+
+If you want to change the endpoint after the GraphQLClient has been initialised, you can use the `setEndpoint()` function.
+
+```js
+import { GraphQLClient } from 'graphql-request'
+
+const client = new GraphQLClient(endpoint)
+
+// Set a single header
+client.setEndpoint(newEndpoint)
+
+```
+
 #### passing-headers-in-each-request
 
 It is possible to pass custom headers for each request. `request()` and `rawRequest()` accept a header object as the third parameter

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,6 +186,15 @@ export class GraphQLClient {
 
     return this
   }
+
+  /**
+   * Change the client endpoint. All subsequent requests will send to this endpoint.
+   */
+  setEndpoint(value: string): GraphQLClient {
+    this.url = value;
+    return this;
+  }
+
 }
 
 async function makeRequest<T = any, V = Variables>({


### PR DESCRIPTION
This PR is requesting to support set endpoint after the GraphQLClient has been initialized.

One use case is the Redux RTK-query. The client needs to get initialized before the Redux store is configured, however if the endpoint is based on user-input, or comes from an async process, the endpoint needs to get updated accordingly, similar to `setHeader`.

Ref: [https://www.graphql-code-generator.com/docs/plugins/typescript-rtk-query](https://www.graphql-code-generator.com/docs/plugins/typescript-rtk-query)