### PR TITLE
fix: resolve headers when cross fetch is not available in environment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ const resolveHeaders = (headers: Dom.RequestInit['headers']): Record<string, str
   if (headers) {
     if (
       (typeof Headers !== 'undefined' && headers instanceof Headers) ||
-      headers instanceof CrossFetch.Headers
+      (CrossFetch && CrossFetch.Headers && headers instanceof CrossFetch.Headers)
     ) {
       oHeaders = HeadersInstanceToPlainObject(headers)
     } else if (Array.isArray(headers)) {


### PR DESCRIPTION
This module supports [using a custom fetch method](https://github.com/prisma-labs/graphql-request#using-a-custom-fetch-method), which is great when fetch is not supported in a given environment.

However, `resolveHeaders` function does not have into account that `cross-fetch` might be undefined. This was creating problems for me when using this module in a Cloudflare worker with the error: `TypeError: Right-hand side of 'instanceof' is not an object`.

This should have tests to avoid regressions, but at this point is quite complex to setup a test environment for this. I would suggest we can use something like https://github.com/hugomrdias/playwright-test and run tests in a service worker, but I left this for a follow up PR as I am not sure about how you would prefer to deal with this.