### PR TITLE
feat(types): export more client types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import createRequestBody from './createRequestBody'
 import { BatchRequestDocument, ClientError, RequestDocument, Variables } from './types'
 import * as Dom from './types.dom'
 
-export { ClientError } from './types'
+export { BatchRequestDocument, ClientError, RequestDocument, Variables }
 
 /**
  * Convert the given headers configuration into a plain object.


### PR DESCRIPTION
This is useful when importing types from type definition files.

Makes this work:

```ts
import { RequestDocument, Variables } from 'graphql-request';
```

rather than having to do something like:

```ts
import { RequestDocument, Variables } from 'graphql-request/dist/types';
```