### PR TITLE
fix: case-insensitive 'Content-type' response header detection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -538,7 +538,7 @@ function getResult(response: Dom.Response): Promise<any> {
   let contentType: string | undefined
 
   response.headers.forEach((value, key) => {
-    if (key.toLowerCase() === 'Content-Type'.toLowerCase()) {
+    if (key.toLowerCase() === 'content-type') {
       contentType = value
     }
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -535,14 +535,20 @@ export default request
  * todo
  */
 function getResult(response: Dom.Response): Promise<any> {
-  const contentType = response.headers.get('Content-Type')
-  if (contentType && contentType.startsWith('application/json')) {
+  let contentType: string | undefined
+
+  response.headers.forEach((value, key) => {
+    if (key.toLowerCase() === 'Content-Type'.toLowerCase()) {
+      contentType = value
+    }
+  })
+
+  if (contentType && contentType.toLowerCase().startsWith('application/json')) {
     return response.json()
   } else {
     return response.text()
   }
 }
-
 /**
  * helpers
  */


### PR DESCRIPTION
Changed the `Content-Type` response header detection to be case-insensitive in the [getResult ](https://github.com/prisma-labs/graphql-request/blob/f5f7286748943665f969082dbe91aed3195e8b7a/src/index.ts#L537)function.

Fixes: #314 