### PR TITLE
fix: include source files in package for source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0-dripip",
   "main": "dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "bundlesize": [
     {


### PR DESCRIPTION
#311 details how source maps are broken - they refer files in the `src` directory which aren't included in the installed package.

This is the easiest fix for this problem. There is no fix which doesn't increase the size of the package other than completely removing the source maps unfortunately.

I've taken this approach rather than embedding the source in the map files as that's what we decided elsewhere in the graphql ecosystem: https://github.com/graphql/graphiql/pull/2047