### PR TITLE
feat: parse string documents to extract the operationName

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ For Node.js v12 you can use [abort-controller](https://github.com/mysticatea/abo
 
 #### Why do I have to install `graphql`?
 
-`graphql-request` uses a TypeScript type from the `graphql` package such that if you are using TypeScript to build your project and you are using `graphql-request` but don't have `graphql` installed TypeScript build will fail. Details [here](https://github.com/prisma-labs/graphql-request/pull/183#discussion_r464453076). If you are a JS user then you do not technically need to install `graphql`. However if you use an IDE that picks up TS types even for JS (like VSCode) then its still in your interest to install `graphql` so that you can benefit from enhanced type safety during development.
+`graphql-request` uses methods exposed by the `graphql` package to handle some internal logic. On top of that, for TypeScript users, some types are used from the `graphql` package to provide better typings.
 
 #### Do I need to wrap my GraphQL documents inside the `gql` template exported by `graphql-request`?
 

--- a/tests/general.test.ts
+++ b/tests/general.test.ts
@@ -1,3 +1,4 @@
+import gql from 'graphql-tag'
 import { GraphQLClient, rawRequest, request } from '../src'
 import { setupTestServer } from './__helpers'
 import * as Dom from '../src/types.dom'
@@ -178,4 +179,36 @@ test('case-insensitive content-type header for custom fetch', async () => {
   const result = await client.request('{ test }')
 
   expect(result).toBe(testData.data)
+})
+
+describe('operationName parsing', () => {
+  it('should work for gql documents', async () => {
+    const mock = ctx.res({ body: { data: { foo: 1 } } })
+    await request(
+      ctx.url,
+      gql`
+        query myGqlOperation {
+          users
+        }
+      `
+    )
+
+    const requestBody = mock.requests[0].body
+    expect(requestBody.operationName).toEqual('myGqlOperation')
+  })
+
+  it('should work for string documents', async () => {
+    const mock = ctx.res({ body: { data: { foo: 1 } } })
+    await request(
+      ctx.url,
+      `
+        query myStringOperation {
+          users
+        }
+      `
+    )
+
+    const requestBody = mock.requests[0].body
+    expect(requestBody.operationName).toEqual('myStringOperation')
+  })
 })


### PR DESCRIPTION
Following [a previous PR](https://github.com/prisma-labs/graphql-request/pull/280) from another contributor that allowed getting the `OperationName` from a GQL operation, I added the possibility to also get it when the document is a string.

Currently, `operationName` could only be extracted from "regular" queries/mutations, and it wouldn't work for operations passed as strings.

In our current project, all our queries and mutations are auto-generated, and they all are strings, hence the `operationName` was never resolved and passed.

I just used the `parser` exposed by `graphql` to get the actual operation from the string, then used the existing logic for getting and setting the operationName if found.