### PR TITLE
feat: include operationName to rawRequest payload if defined in gql

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -219,6 +219,8 @@ export class GraphQLClient {
       fetchOptions.signal = rawRequestOptions.signal
     }
 
+    const { operationName } = resolveRequestDocument(rawRequestOptions.query)
+
     return makeRequest<T, V>({
       url,
       query: rawRequestOptions.query,
@@ -227,7 +229,7 @@ export class GraphQLClient {
         ...resolveHeaders(headers),
         ...resolveHeaders(rawRequestOptions.requestHeaders),
       },
-      operationName: undefined,
+      operationName,
       fetch,
       method,
       fetchOptions,


### PR DESCRIPTION
Following PR #280 which added `operationName` to the payload in `request()`,  this PR adds `operationName` to the payload in `rawRequest()`.

Currently, `operationName` is [explicitly passed](https://github.com/prisma-labs/graphql-request/blob/master/src/index.ts#L230) as `undefined` to the request body. We would like to be able to reap the benefits offered by `rawRequest()` while also being able to pass `operationName` in the request body.