### PR TITLE
feat: dynamic headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Minimal GraphQL client supporting Node and browsers for scripts or simple apps
   - [Authentication via HTTP header](#authentication-via-http-header)
     - [Incrementally setting headers](#incrementally-setting-headers)
   - [Passing Headers in each request](#passing-headers-in-each-request)
+  - [Passing dynamic headers to the client](#passing-dynamic-headers-to-the-client)
   - [Passing more options to `fetch`](#passing-more-options-to-fetch)
     - [Custom JSON serializer](#custom-json-serializer)
   - [Using GraphQL Document variables](#using-graphql-document-variables)
@@ -212,6 +213,31 @@ const requestHeaders = {
 
 // Overrides the clients headers with the passed values
 const data = await client.request(query, variables, requestHeaders)
+```
+
+#### Passing dynamic headers to the client
+
+It's possible to recalculate the global client headers dynamically before each request.
+To do that, pass a function that returns the headers to the `headers` property when creating a new `GraphQLClient`.
+
+```js
+import { GraphQLClient } from 'graphql-request'
+
+const client = new GraphQLClient(endpoint,
+  { 
+    headers: () => ({ 'X-Sent-At-Time': Date.now() })
+  }
+)
+
+const query = gql`
+  query getCars {
+    cars {
+      name
+    }
+  }
+
+// Function saved in the client runs and calculates fresh headers before each request
+const data = await client.request(query)
 ```
 
 ### Passing more options to `fetch`

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ import {
   RawRequestExtendedOptions,
   RequestExtendedOptions,
   Variables,
+  PatchedRequestInit,
+  MaybeFunction,
 } from './types'
 import * as Dom from './types.dom'
 
@@ -190,9 +192,9 @@ const get = async <V = Variables>({
  */
 export class GraphQLClient {
   private url: string
-  private options: Dom.RequestInit
+  private options: PatchedRequestInit
 
-  constructor(url: string, options?: Dom.RequestInit) {
+  constructor(url: string, options?: PatchedRequestInit) {
     this.url = url
     this.options = options || {}
   }
@@ -228,7 +230,7 @@ export class GraphQLClient {
       query: rawRequestOptions.query,
       variables: rawRequestOptions.variables,
       headers: {
-        ...resolveHeaders(headers),
+        ...resolveHeaders(callOrIdentity(headers)),
         ...resolveHeaders(rawRequestOptions.requestHeaders),
       },
       operationName,
@@ -267,7 +269,7 @@ export class GraphQLClient {
       query,
       variables: requestOptions.variables,
       headers: {
-        ...resolveHeaders(headers),
+        ...resolveHeaders(callOrIdentity(headers)),
         ...resolveHeaders(requestOptions.requestHeaders),
       },
       operationName,
@@ -309,7 +311,7 @@ export class GraphQLClient {
       query: queries,
       variables,
       headers: {
-        ...resolveHeaders(headers),
+        ...resolveHeaders(callOrIdentity(headers)),
         ...resolveHeaders(batchRequestOptions.requestHeaders),
       },
       operationName: undefined,
@@ -590,6 +592,10 @@ function resolveRequestDocument(document: RequestDocument): { query: string; ope
   const operationName = extractOperationName(document)
 
   return { query: print(document), operationName }
+}
+
+function callOrIdentity<T>(value: MaybeFunction<T>) {
+  return typeof value === 'function' ? (value as () => T)() : value;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,12 @@ export class ClientError extends Error {
   }
 }
 
+export type MaybeFunction<T> = T | (() => T);
+
 export type RequestDocument = string | DocumentNode
+
+export type PatchedRequestInit = Omit<Dom.RequestInit, "headers">
+  & {headers?: MaybeFunction<Dom.RequestInit['headers']>};
 
 export type BatchRequestDocument<V = Variables> = {
   document: RequestDocument

--- a/tests/headers.test.ts
+++ b/tests/headers.test.ts
@@ -92,6 +92,26 @@ describe('using class', () => {
       });
 
     })
+
+    describe('gets fresh dynamic headers before each request', () => {
+      test('with request method', async () => {
+        const objectChangedThroughReference = { 'x-foo': 'old' }
+        const client = new GraphQLClient(ctx.url, { headers: () => objectChangedThroughReference });
+        objectChangedThroughReference['x-foo'] = 'new';
+        const mock = ctx.res()
+        await client.request(`{ me { id } }`);
+        expect(mock.requests[0].headers['x-foo']).toEqual('new')
+      })
+
+      test('with rawRequest method', async () => {
+        const objectChangedThroughReference = { 'x-foo': 'old' }
+        const client = new GraphQLClient(ctx.url, { headers: () => objectChangedThroughReference });
+        objectChangedThroughReference['x-foo'] = 'new';
+        const mock = ctx.res()
+        await client.rawRequest(`{ me { id } }`);
+        expect(mock.requests[0].headers['x-foo']).toEqual('new')
+      })
+    })
   })
 })
 


### PR DESCRIPTION
Continuation of https://github.com/prisma-labs/graphql-request/pull/91#issuecomment-1096658311

This is just a small, incomplete showcase of my train of thought.

I see a few ways do do this:

Option 1: The code in this PR is the "naive" version in the sense that as you can see in src/index.ts I'm just going over each occurrence of `Dom.RequestInit['headers']` and replacing it with `original Dom type | dynamic type` which is not very elegant, and muddles the actual dom types - which is why I'm not very keen on the `Record<string, string | () => string` approach from the original PR from a few years ago.

Option 2: What would be potentially more elegant is just `Dom.RequestInit['headers'] | () => Dom.RequestInit['headers']`, which does not add any further union types to the already existing Dom type. This recalculates *all* headers on each requests though, which is a bit wasteful

Option 3: Force users to do it themselves (do nothing in this lib). Just say "write your own wrapper for GraphQLClient.request and pass fresh requestHeaders in it each time", or use some magic managed proxy (like I wrote in the original PR). I coud write some docs if this is the choice

@jasonkuhrt what do you think? I like options 2 and 3 the most because they respect graphql-request's current implementation of "bro just give me HeadersInit in requestHeaders without any magic"