### PR TITLE
feat!: Invoke responseMiddleware in error cases as well

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -267,12 +267,19 @@ export class GraphQLClient {
       method,
       fetchOptions,
       middleware: requestMiddleware,
-    }).then((response) => {
-      if (responseMiddleware) {
-        responseMiddleware(response)
-      }
-      return response
     })
+      .then((response) => {
+        if (responseMiddleware) {
+          responseMiddleware(response)
+        }
+        return response
+      })
+      .catch((error) => {
+        if (responseMiddleware) {
+          responseMiddleware(error)
+        }
+        throw error
+      })
   }
 
   /**
@@ -326,12 +333,19 @@ export class GraphQLClient {
       method,
       fetchOptions,
       middleware: requestMiddleware,
-    }).then((response) => {
-      if (responseMiddleware) {
-        responseMiddleware(response)
-      }
-      return response.data
     })
+      .then((response) => {
+        if (responseMiddleware) {
+          responseMiddleware(response)
+        }
+        return response.data
+      })
+      .catch((error) => {
+        if (responseMiddleware) {
+          responseMiddleware(error)
+        }
+        throw error
+      })
   }
 
   /**
@@ -379,12 +393,19 @@ export class GraphQLClient {
       method,
       fetchOptions,
       middleware: requestMiddleware,
-    }).then((response) => {
-      if (responseMiddleware) {
-        responseMiddleware(response)
-      }
-      return response.data
     })
+      .then((response) => {
+        if (responseMiddleware) {
+          responseMiddleware(response)
+        }
+        return response.data
+      })
+      .catch((error) => {
+        if (responseMiddleware) {
+          responseMiddleware(error)
+        }
+        throw error
+      })
   }
 
   setHeaders(headers: Dom.RequestInit['headers']): GraphQLClient {

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,7 +71,7 @@ export interface Response<T> {
 export type PatchedRequestInit = Omit<Dom.RequestInit, 'headers'> & {
   headers?: MaybeFunction<Dom.RequestInit['headers']>
   requestMiddleware?: (request: Dom.RequestInit) => Dom.RequestInit
-  responseMiddleware?: (response: Response<unknown>) => void
+  responseMiddleware?: (response: Response<unknown> | Error) => void
 }
 
 export type BatchRequestDocument<V = Variables> = {


### PR DESCRIPTION
I really like the new middleware feature and would like to use it for some basic error handling.

Unfortunately, the current implementation only invokes the middleware if the fetch request has been resolved, meaning it will never get called on request failure.


BREAKING CHANGE:

Middleware will get either the response or error now, whereas before it would only get the response and never run in the error case.