### PR TITLE
feat: Allow async requestMiddleware

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,7 @@ const post = async <V = Variables>({
   variables?: V
   headers?: Dom.RequestInit['headers']
   operationName?: string
-  middleware?: (request: Dom.RequestInit) => Dom.RequestInit
+  middleware?: (request: Dom.RequestInit) => Dom.RequestInit | Promise<Dom.RequestInit>
 }) => {
   const body = createRequestBody(query, variables, operationName, fetchOptions.jsonSerializer)
 
@@ -172,7 +172,7 @@ const post = async <V = Variables>({
     ...fetchOptions,
   }
   if (middleware) {
-    options = middleware(options)
+    options = await Promise.resolve(middleware(options))
   }
   return await fetch(url, options)
 }
@@ -197,7 +197,7 @@ const get = async <V = Variables>({
   variables?: V
   headers?: HeadersInit
   operationName?: string
-  middleware?: (request: Dom.RequestInit) => Dom.RequestInit
+  middleware?: (request: Dom.RequestInit) => Dom.RequestInit | Promise<Dom.RequestInit>
 }) => {
   const queryParams = buildGetQueryParams<V>({
     query,
@@ -212,7 +212,7 @@ const get = async <V = Variables>({
     ...fetchOptions,
   }
   if (middleware) {
-    options = middleware(options)
+    options = await Promise.resolve(middleware(options))
   }
   return await fetch(`${url}?${queryParams}`, options)
 }
@@ -458,7 +458,7 @@ async function makeRequest<T = any, V = Variables>({
   fetch: any
   method: string
   fetchOptions: Dom.RequestInit
-  middleware?: (request: Dom.RequestInit) => Dom.RequestInit
+  middleware?: (request: Dom.RequestInit) => Dom.RequestInit | Promise<Dom.RequestInit>
 }): Promise<Response<T>> {
   const fetcher = method.toUpperCase() === 'POST' ? post : get
   const isBathchingQuery = Array.isArray(query)

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,7 @@ export interface Response<T> {
 
 export type PatchedRequestInit = Omit<Dom.RequestInit, 'headers'> & {
   headers?: MaybeFunction<Dom.RequestInit['headers']>
-  requestMiddleware?: (request: Dom.RequestInit) => Dom.RequestInit
+  requestMiddleware?: (request: Dom.RequestInit) => Dom.RequestInit | Promise<Dom.RequestInit>
   responseMiddleware?: (response: Response<unknown> | Error) => void
 }
 

--- a/tests/general.test.ts
+++ b/tests/general.test.ts
@@ -163,6 +163,41 @@ describe('middleware', () => {
     })
   })
 
+  describe('async request middleware', () => {
+    beforeEach(() => {
+      ctx.res({
+        body: {
+          data: {
+            result: 123,
+          },
+        },
+      })
+
+      requestMiddleware = jest.fn(async (req) => ({ ...req }))
+      client = new GraphQLClient(ctx.url, {
+        requestMiddleware,
+      })
+    })
+
+    it('request', async () => {
+      const requestPromise = client.request<{ result: number }>(`x`)
+      expect(requestMiddleware).toBeCalledTimes(1)
+      await requestPromise
+    })
+
+    it('rawRequest', async () => {
+      const requestPromise = client.rawRequest<{ result: number }>(`x`)
+      expect(requestMiddleware).toBeCalledTimes(1)
+      await requestPromise
+    })
+
+    it('batchRequests', async () => {
+      const requestPromise = client.batchRequests<{ result: number }>([{ document: `x` }])
+      expect(requestMiddleware).toBeCalledTimes(1)
+      await requestPromise
+    })
+  })
+
   describe('failed requests', () => {
     beforeEach(() => {
       ctx.res({


### PR DESCRIPTION
Currently, it's not possible to pass any async data to request middlewares. For example, fetching and auth token. I think using `Promise.resolve` is the cleanest solution and shouldn't add any noticeable overhead to non async middlewares.