### PR TITLE
fix(client): accurate typings for `client.request()` with `TypedDocumentNode` document and `RequestOptions` argument

### DIFF
--- a/examples/typed-document-node.ts
+++ b/examples/typed-document-node.ts
@@ -1,7 +1,7 @@
 import { TypedDocumentNode } from '@graphql-typed-document-node/core'
 import { parse } from 'graphql'
 
-import { request } from '../src'
+import { request, GraphQLClient } from '../src'
 ;(async function () {
   const endpoint = 'https://graphql-yoga.com/api/graphql'
 
@@ -14,6 +14,24 @@ import { request } from '../src'
   const variables = {}
 
   const data = await request(endpoint, query, variables)
+
+  console.log(data.greetings)
+})().catch(console.error)
+;(async function () {
+  const endpoint = 'https://graphql-yoga.com/api/graphql'
+
+  const client = new GraphQLClient(endpoint)
+
+  const query: TypedDocumentNode<{ greetings: string }, never | Record<any, never>> = parse(/* GraphQL */ `
+    query greetings {
+      greetings
+    }
+  `)
+
+  const variables = {}
+
+  const data = await client.request({ document: query })
+  // const data = await client.request({ document: query, variables: { a: 1 } })
 
   console.log(data.greetings)
 })().catch(console.error)

--- a/src/index.ts
+++ b/src/index.ts
@@ -286,7 +286,7 @@ export class GraphQLClient {
       ? [variables?: V, requestHeaders?: Dom.RequestInit['headers']]
       : [variables: V, requestHeaders?: Dom.RequestInit['headers']]
   ): Promise<T>
-  request<T = any, V = Variables>(options: RequestOptions<V>): Promise<T>
+  request<T = any, V = Variables>(options: RequestOptions<V, T>): Promise<T>
   request<T = any, V = Variables>(
     documentOrOptions: RequestDocument | TypedDocumentNode<T, V> | RequestOptions<V>,
     ...variablesAndRequestHeaders: V extends Record<any, never> // do we have explicitly no variables allowed?


### PR DESCRIPTION


Fixes #380