### PR TITLE
doc(readme): add documentation about async middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,20 @@ function middleware(request: RequestInit) {
 const client = new GraphQLClient(endpoint, { requestMiddleware: middleware })
 ```
 
+It's also possible to use an async function as a request middleware. The resolved data will be passed to the request:
+
+```ts
+async function middleware(request: RequestInit) {
+  const token = await getToken()
+  return {
+    ...request,
+    headers: { ...request.headers, 'x-auth-token': token },
+  }
+}
+
+const client = new GraphQLClient(endpoint, { requestMiddleware: middleware })
+```
+
 Response middleware example (log request trace id if error caused):
 
 ```ts


### PR DESCRIPTION
Thanks to https://github.com/prisma-labs/graphql-request/pull/379, now you can use an async function as a request middleware.

I think it's very helpful feature in a lot of use-cases, so it should be explicitly described in the readme documentation.