### PR TITLE
fix #388,#373 add application/graphql+json and application/graphql-response+json content type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -663,7 +663,7 @@ async function getResult(response: Dom.Response, jsonSerializer = defaultJsonSer
     }
   })
 
-  if (contentType && contentType.toLowerCase().startsWith('application/json')) {
+  if (contentType && (contentType.toLowerCase().startsWith('application/json') || contentType.toLowerCase().startsWith("application/graphql+json") || contentType.toLowerCase().startsWith("application/graphql-response+json"))) {
     return jsonSerializer.parse(await response.text())
   } else {
     return response.text()

--- a/tests/general.test.ts
+++ b/tests/general.test.ts
@@ -60,6 +60,50 @@ test('minimal raw query with response headers', async () => {
   expect(headers.get('X-Custom-Header')).toEqual(reqHeaders!['X-Custom-Header'])
 })
 
+test('minimal raw query with response headers and new graphql content type', async () => {
+  const { headers: reqHeaders, body } = ctx.res({
+    headers: {
+      'Content-Type': 'application/graphql+json',
+    },
+    body: {
+      data: {
+        me: {
+          id: 'some-id',
+        },
+      },
+      extensions: {
+        version: '1',
+      },
+    },
+  }).spec
+
+  const { headers, ...result } = await rawRequest(ctx.url, `{ me { id } }`)
+
+  expect(result).toEqual({ ...body, status: 200 })
+})
+
+test('minimal raw query with response headers and application/graphql-response+json response type', async () => {
+  const { headers: reqHeaders, body } = ctx.res({
+    headers: {
+      'Content-Type': 'application/graphql-response+json',
+    },
+    body: {
+      data: {
+        me: {
+          id: 'some-id',
+        },
+      },
+      extensions: {
+        version: '1',
+      },
+    },
+  }).spec
+
+  const { headers, ...result } = await rawRequest(ctx.url, `{ me { id } }`)
+
+  expect(result).toEqual({ ...body, status: 200 })
+})
+
 test('content-type with charset', async () => {
   const { data } = ctx.res({
     // headers: { 'Content-Type': 'application/json; charset=utf-8' },


### PR DESCRIPTION
Hi All,

This adds the `application/graphql+json` ( some servers use this) and the new standard `application/graphql-response+json` content types ( https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#serialization-format ) which will help stop new users to this library trying to figure out why request is throwing an error for a valid query.

Let me know if I need to change anything

Thanks!