### PR TITLE
fix: `variables` not being required by ts (#409)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Minimal GraphQL client supporting Node and browsers for scripts or simple apps
   - [Usage](#usage)
   - [Node Version Support](#node-version-support)
   - [Community](#community)
-      - [GraphQL Code Generator's GraphQL-Request TypeScript Plugin](#graphql-code-generators-graphql-request-typescript-plugin)
+    - [GraphQL Code Generator's GraphQL-Request TypeScript Plugin](#graphql-code-generators-graphql-request-typescript-plugin)
   - [Examples](#examples)
     - [Authentication via HTTP header](#authentication-via-http-header)
       - [Incrementally setting headers](#incrementally-setting-headers)
@@ -42,9 +42,9 @@ Minimal GraphQL client supporting Node and browsers for scripts or simple apps
       - [Ignore](#ignore)
       - [All](#all)
   - [FAQ](#faq)
-      - [Why do I have to install `graphql`?](#why-do-i-have-to-install-graphql)
-      - [Do I need to wrap my GraphQL documents inside the `gql` template exported by `graphql-request`?](#do-i-need-to-wrap-my-graphql-documents-inside-the-gql-template-exported-by-graphql-request)
-      - [What's the difference between `graphql-request`, Apollo and Relay?](#whats-the-difference-between-graphql-request-apollo-and-relay)
+    - [Why do I have to install `graphql`?](#why-do-i-have-to-install-graphql)
+    - [Do I need to wrap my GraphQL documents inside the `gql` template exported by `graphql-request`?](#do-i-need-to-wrap-my-graphql-documents-inside-the-gql-template-exported-by-graphql-request)
+    - [What's the difference between `graphql-request`, Apollo and Relay?](#whats-the-difference-between-graphql-request-apollo-and-relay)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -124,8 +124,8 @@ You are free to try using other versions of Node (e.g. `13.x`) with `graphql-req
 Installing and configuring [GraphQL Code Generator](https://www.the-guild.dev/graphql/codegen) requires a few steps in order to get end-to-end typed GraphQL operations using the provided `graphql()` helper:
 
 ```ts
-import request from 'graphql-request';
-import { graphql } from './gql/gql';
+import request from 'graphql-request'
+import { graphql } from './gql/gql'
 
 const getMovieQueryDocument = graphql(/* GraphQL */ `
   query getMovie($title: String!) {
@@ -136,18 +136,18 @@ const getMovieQueryDocument = graphql(/* GraphQL */ `
       }
     }
   }
-`);
-
+`)
 
 const data = await request(
   'https://api.graph.cool/simple/v1/cixos23120m0n0173veiiwrjr',
   getMovieQueryDocument,
   // variables are type-checked!
-  { title: "Inception" }
+  { title: 'Inception' }
 )
 
 // `data.Movie` is typed!
 ```
+
 [_The complete example is available in the GraphQL Code Generator repository_](https://github.com/dotansimha/graphql-code-generator/tree/master/examples/front-end/react/graphql-request)
 
 Visit GraphQL Code Generator's dedicated guide to get started: https://www.the-guild.dev/graphql/codegen/docs/guides/react-vue.
@@ -646,7 +646,6 @@ It is possible with `graphql-request` to use [batching](https://github.com/graph
 
 ```ts
 import { batchRequests } from 'graphql-request'
-
 ;(async function () {
   const endpoint = 'https://api.spacex.land/graphql/'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,13 +285,8 @@ export class GraphQLClient {
    * Send a GraphQL document to the server.
    */
   request<T = any, V = Variables>(
-    document: string,
-    variables?: V,
-    requestHeaders?: Dom.RequestInit['headers']
-  ): Promise<T>
-  request<T = any, V = Variables>(
-    document: DocumentNode | TypedDocumentNode<T, V>,
-    ..._variablesAndRequestHeaders: V extends Record<any, never> // do we have explicitly no variables allowed?
+    document: RequestDocument | TypedDocumentNode<T, V>,
+    ...variablesAndRequestHeaders: V extends Record<any, never> // do we have explicitly no variables allowed?
       ? [variables?: V, requestHeaders?: Dom.RequestInit['headers']]
       : keyof RemoveIndex<V> extends never // do we get an empty variables object?
       ? [variables?: V, requestHeaders?: Dom.RequestInit['headers']]
@@ -566,18 +561,12 @@ export async function rawRequest<T = any, V = Variables>(
  */
 export async function request<T = any, V = Variables>(
   url: string,
-  document: DocumentNode | TypedDocumentNode<T, V>,
-  ..._variablesAndRequestHeaders: V extends Record<any, never> // do we have explicitly no variables allowed?
+  document: RequestDocument | TypedDocumentNode<T, V>,
+  ...variablesAndRequestHeaders: V extends Record<any, never> // do we have explicitly no variables allowed?
     ? [variables?: V, requestHeaders?: Dom.RequestInit['headers']]
     : keyof RemoveIndex<V> extends never // do we get an empty variables object?
     ? [variables?: V, requestHeaders?: Dom.RequestInit['headers']]
     : [variables: V, requestHeaders?: Dom.RequestInit['headers']]
-): Promise<T>
-export async function request<T = any, V = Variables>(
-  url: string,
-  document: string,
-  variables?: V,
-  requestHeaders?: Dom.RequestInit['headers']
 ): Promise<T>
 export async function request<T = any, V = Variables>(options: RequestExtendedOptions<V, T>): Promise<T>
 export async function request<T = any, V = Variables>(
@@ -663,7 +652,12 @@ async function getResult(response: Dom.Response, jsonSerializer = defaultJsonSer
     }
   })
 
-  if (contentType && (contentType.toLowerCase().startsWith('application/json') || contentType.toLowerCase().startsWith("application/graphql+json") || contentType.toLowerCase().startsWith("application/graphql-response+json"))) {
+  if (
+    contentType &&
+    (contentType.toLowerCase().startsWith('application/json') ||
+      contentType.toLowerCase().startsWith('application/graphql+json') ||
+      contentType.toLowerCase().startsWith('application/graphql-response+json'))
+  ) {
     return jsonSerializer.parse(await response.text())
   } else {
     return response.text()

--- a/tests/typed-document-node.test.ts
+++ b/tests/typed-document-node.test.ts
@@ -5,7 +5,7 @@ import { setupTestServer } from './__helpers'
 
 const ctx = setupTestServer()
 
-test('typed-document-node code should TS compile', async () => {
+test('typed-document-node code should TS compile with variables', async () => {
   ctx.res({ body: { data: { foo: 1 } } })
 
   const query: TypedDocumentNode<{ echo: string }, { str: string }> = parse(/* GraphQL */ `
@@ -23,37 +23,29 @@ test('typed-document-node code should TS compile', async () => {
 
   await request(ctx.url, query, { str: 'Hi' })
 
-  const document: TypedDocumentNode<{ echo: string }, { str: string }> = parse(/* GraphQL */ `
-    query greetings($str: String!) {
-      echo(str: $echo)
-    }
-  `)
-
-  // variables are mandatory here!
-
   // @ts-expect-error 'variables' is declared here.
   await request({
     url: ctx.url,
-    document,
+    document: query,
   })
 
   await request({
     url: ctx.url,
-    document,
+    document: query,
     // @ts-expect-error Property 'str' is missing in type '{}' but required in type '{ str: string; }'.
     variables: {},
   })
 
   await request({
     url: ctx.url,
-    document,
+    document: query,
     // @ts-expect-error Type '{ aaa: string; }' is not assignable to type '{ str: string; }'.
     variables: { aaa: 'aaa' },
   })
 
   await request({
     url: ctx.url,
-    document,
+    document: query,
     // @ts-expect-error Type 'number' is not assignable to type 'string'.ts(2322)
     variables: { str: 1 },
   })
@@ -64,12 +56,71 @@ test('typed-document-node code should TS compile', async () => {
     variables: { whatever: 'not typed' },
   })
 
+  await request<{ echo: string }, { str: string }>({
+    url: ctx.url,
+    document: 'a graphql query',
+    variables: { str: 'Hi' },
+  })
+
+  await request<{ echo: string }, { str: string }>({
+    url: ctx.url,
+    document: 'a graphql query',
+    // @ts-expect-error Type 'number' is not assignable to type 'string'.ts(2322)
+    variables: { str: 1 },
+  })
+
+  await request<{ echo: string }, { str: string }>({
+    url: ctx.url,
+    document: 'a graphql query',
+    // @ts-expect-error Type '{ aaa: string; }' is not assignable to type '{ str: string; }'.
+    variables: { aaa: 'aaa' },
+  })
+
   await request({
     url: ctx.url,
-    document,
+    document: query,
     variables: {
       str: 'foo',
     },
+  })
+
+  expect(1).toBe(1)
+})
+
+test('typed-document-node code should TS compile without variables', async () => {
+  ctx.res({ body: { data: { foo: 1 } } })
+
+  const query: TypedDocumentNode<{ echo: string }> = parse(/* GraphQL */ `
+    query greetings {
+      echo
+    }
+  `)
+
+  // variables are not mandatory here!
+
+  await request(ctx.url, query, {})
+  await request(ctx.url, query)
+
+  await request({
+    url: ctx.url,
+    document: query,
+  })
+
+  await request({
+    url: ctx.url,
+    document: query,
+    variables: {},
+  })
+
+  await request({
+    url: ctx.url,
+    document: 'a graphql query',
+    variables: {},
+  })
+
+  await request({
+    url: ctx.url,
+    document: 'a graphql query',
   })
 
   expect(1).toBe(1)


### PR DESCRIPTION
For more information, see #409. I hope I didn't miss something but this simplifies the signature of `client.request` and `request` while also fixing the issue that a missing `variables` is not being type checked by TypeScript. The changes in `README.md` are only because someone forgot to run `yarn format` before pushing, maybe a hook running it automatically before commiting would make sense if this occurs regularly.