### PR TITLE
feat: pass `operationName` and `variables` to `requestMiddleware`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import {
   MaybeFunction,
   Response,
   RemoveIndex,
-  RequestMiddlware,
+  RequestMiddleware,
   VariablesAndRequestHeaders,
 } from './types'
 import * as Dom from './types.dom'
@@ -157,7 +157,7 @@ const post = async <V extends Variables = Variables>({
   variables?: V
   headers?: Dom.RequestInit['headers']
   operationName?: string
-  middleware?: RequestMiddlware
+  middleware?: RequestMiddleware<V>
 }) => {
   const body = createRequestBody(query, variables, operationName, fetchOptions.jsonSerializer)
 
@@ -171,7 +171,7 @@ const post = async <V extends Variables = Variables>({
     ...fetchOptions,
   }
   if (middleware) {
-    ;({ url, ...init } = await Promise.resolve(middleware({ ...init, url })))
+    ;({ url, ...init } = await Promise.resolve(middleware({ ...init, url, operationName, variables })))
   }
   return await fetch(url, init)
 }
@@ -196,7 +196,7 @@ const get = async <V extends Variables = Variables>({
   variables?: V
   headers?: Dom.RequestInit['headers']
   operationName?: string
-  middleware?: RequestMiddlware
+  middleware?: RequestMiddleware<V>
 }) => {
   const queryParams = buildGetQueryParams<V>({
     query,
@@ -211,7 +211,7 @@ const get = async <V extends Variables = Variables>({
     ...fetchOptions,
   }
   if (middleware) {
-    ;({ url, ...init } = await Promise.resolve(middleware({ ...init, url })))
+    ;({ url, ...init } = await Promise.resolve(middleware({ ...init, url, operationName, variables })))
   }
   return await fetch(`${url}?${queryParams}`, init)
 }
@@ -459,7 +459,7 @@ async function makeRequest<T = any, V extends Variables = Variables>({
   fetch: any
   method: string
   fetchOptions: Dom.RequestInit
-  middleware?: RequestMiddlware
+  middleware?: RequestMiddleware<V>
 }): Promise<Response<T>> {
   const fetcher = method.toUpperCase() === 'POST' ? post : get
   const isBathchingQuery = Array.isArray(query)

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,7 @@ export interface Response<T> {
 
 export type PatchedRequestInit = Omit<Dom.RequestInit, 'headers'> & {
   headers?: MaybeFunction<Dom.RequestInit['headers']>
-  requestMiddleware?: RequestMiddlware
+  requestMiddleware?: RequestMiddleware
   responseMiddleware?: (response: Response<unknown> | Error) => void
 }
 
@@ -117,12 +117,14 @@ export type BatchRequestsExtendedOptions<V extends Variables = Variables> = {
   url: string
 } & BatchRequestsOptions<V>
 
-export type RequestMiddlware = (
-  request: RequestExtendedInit
+export type RequestMiddleware<V extends Variables = Variables> = (
+  request: RequestExtendedInit<V>
 ) => RequestExtendedInit | Promise<RequestExtendedInit>
 
-type RequestExtendedInit = Dom.RequestInit & {
+type RequestExtendedInit<V extends Variables = Variables> = Dom.RequestInit & {
   url: string
+  operationName?: string
+  variables?: V
 }
 
 export type VariablesAndRequestHeaders<V extends Variables> = V extends Record<any, never> // do we have explicitly no variables allowed?


### PR DESCRIPTION
- This is a follow up to #398
- As discussed, we should merge the typescript update (#411) before this one 
- This is based on #410

